### PR TITLE
Fix hashtag

### DIFF
--- a/actdocs/static/sponsors.html
+++ b/actdocs/static/sponsors.html
@@ -355,7 +355,7 @@ src="[% make_uri_info('images/logos/perl-careers.png') %]" alt="Perl Careers" ti
 
 <p>For more than 30 years, we have worked with leading science and medical experts as well as acclaimed photographers to provide a central source for the best scientific imagery and footage available. We have more than 400,000 images and 30,000 video clips to choose from, with hundreds of new additions added to the website each week. You can search, download and purchase material from our website or, if you want to save time, simply take advantage of our free expert research service.</p>
 
-<p>Perl has played a key part in our business. The Perl community has given assistance and help along the way.  We are extremely proud to sponsor the 2015 London Perl Workshop.</p>
+<p>Perl has played a key part in our business. The Perl community has given assistance and help along the way.  We are extremely proud to sponsor the 2016 London Perl Workshop.</p>
 </td>
 <td valign="top">
 <a href="http://www.sciencephoto.com" target="_new"><img src="[%

--- a/actdocs/templates/ui
+++ b/actdocs/templates/ui
@@ -53,7 +53,7 @@
        [% content %]
 
         <div style="align: right">
-          <a href="https://twitter.com/intent/tweet?button_hashtag=lpw2015" class="twitter-hashtag-button" data-related="shadowcat_mdk">Tweet #lpw2015</a>
+          <a href="https://twitter.com/intent/tweet?button_hashtag=lpw2016" class="twitter-hashtag-button" data-related="shadowcat_mdk">Tweet #lpw2016</a>
 <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0];if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src="//platform.twitter.com/widgets.js";fjs.parentNode.insertBefore(js,fjs);}}(document,"script","twitter-wjs");</script>
         </div>
      </div>
@@ -170,7 +170,7 @@
 
       <hr />
 
-      <a href="https://twitter.com/share" class="twitter-share-button" data-text="London Perl Workshop 2015:" data-via="shadowcat_mdk" data-hashtags="lpw2015">Tweet</a>
+      <a href="https://twitter.com/share" class="twitter-share-button" data-text="London Perl Workshop 2016:" data-via="shadowcat_mdk" data-hashtags="lpw2016">Tweet</a>
       <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0];if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src="//platform.twitter.com/widgets.js";fjs.parentNode.insertBefore(js,fjs);}}(document,"script","twitter-wjs");</script>
 
 <iframe src="//www.facebook.com/plugins/like.php?href=http%3A%2F%2Fwww.londonperlworkshop.org.uk&amp;send=false&amp;layout=button_count&amp;width=140&amp;show_faces=true&amp;action=like&amp;colorscheme=light&amp;font=verdana&amp;height=21" scrolling="no" frameborder="0" style="border:none; overflow:hidden; width:140px; height:21px;" allowTransparency="true"></iframe>


### PR DESCRIPTION
- fix hashtag: should be `#lpw2016`
- fix lone remaining "2015" reference

The other one reference to "2015" in actdocs/static/index.html should be left alone, as it  references the time in which Mark announced that he will be standing down as organiser, so... despite appearing in "git grep 2015", _that_ one should not be fixed. This should.
